### PR TITLE
Updated .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: perl
 perl:
-  - "5.12"
-  - "5.14"
-  - "5.16"
-  - "5.18"
-  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
+  - "5.28"
+  - "5.30"
 
 before_install:
-  cpanm -n Devel::Cover::Report::Coveralls
-script:
-  perl Build.PL && ./Build build && cover -test -report coveralls
+  - cpanm -n Module::Build
+  - cpanm -n Devel::Cover::Report::Coveralls
+
+script: perl Build.PL && ./Build build && cover -test -report coveralls


### PR DESCRIPTION
Hello! This is from [pullrequest.club](https://pullrequest.club/).

It seems from the [documentation](https://metacpan.org/pod/Tie::Hash::FixedKeys) that this module is left on CPAN only as an example of using tied hashes?

I have updated `.travis.yml` to use the Ubuntu 16.04 (Xenial) build environment. In this environment Perl versions before 5.22 are not available, see

https://travis-ci.community/t/failure-with-perl-5-16-5-18-5-20/2458

Also, starting from Perl 5.22 `Module::Build` is not in core anymore, see:

https://metacpan.org/pod/release/RJBS/perl-5.22.0-RC2/pod/perldelta.pod

so `Module::Build` was added as a `before_install` dependency in `.travis.yml`.

Please let me know if there are other things you would like to do with this module repository! 
