### PR TITLE
basic cleanup actions

### DIFF
--- a/.github/workflows/perltest.yml
+++ b/.github/workflows/perltest.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-test.yml@main
+    uses: XSven/github_workflows/.github/workflows/cpan-test.yml@development
     with:
       perl_version: "[ 'latest' ]"
 

--- a/Build.PL
+++ b/Build.PL
@@ -1,24 +1,31 @@
+use strict;
+use warnings;
+
 use Module::Build;
 my $build = Module::Build->new(
   module_name => 'Tie::Hash::FixedKeys',
   license => 'perl',
+  release_status => 'stable',
+  configure_requires => {
+    'Module::Build' => '0.4234',
+  },
   requires => {
-    perl           => '5.6.0',
+    perl                  => '5.6.0',
+    'Attribute::Handlers' => '0.76',
   },
   create_makefile_pl => 'traditional',
   meta_merge => {
     'meta-spec' => { version => 2 },
     resources => {
       repository => {
-       type => 'git',
-       url  => 'git://github.com/davorg-cpan/tie-hash-fixedkeys.git',
-       web  => 'https://github.com/davorg-cpan/tie-hash-fixedkeys',
+        type => 'git',
+        url  => 'git://github.com/davorg-cpan/tie-hash-fixedkeys.git',
+        web  => 'https://github.com/davorg-cpan/tie-hash-fixedkeys',
       },
       bugtracker => {
-       web  => 'https://github.com/davorg-cpan/tie-hash-fixedkeys/issues',
+        web  => 'https://github.com/davorg-cpan/tie-hash-fixedkeys/issues',
       },
     },
   },
 );
 $build->create_build_script;
-

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,6 +1,5 @@
 Changes
 lib/Tie/Hash/FixedKeys.pm
-Makefile.PL
 Build.PL
 MANIFEST
 t/test.t
@@ -8,5 +7,3 @@ t/pod.t
 t/pod-coverage.t
 COPYING
 README
-META.yml                                 Module meta-data (added by MakeMaker)
-META.json

--- a/lib/Tie/Hash/FixedKeys.pm
+++ b/lib/Tie/Hash/FixedKeys.pm
@@ -101,7 +101,7 @@ sub STORE {
   my ($self, $key, $val) = @_;
 
   unless (exists $self->{$key}) {
-    croak "invalid key [$key] in hash\n";
+    croak "invalid key [$key] in hash";
   }
   $self->{$key} = $val;
 }

--- a/lib/Tie/Hash/FixedKeys.pm
+++ b/lib/Tie/Hash/FixedKeys.pm
@@ -1,5 +1,3 @@
-# $Id$
-
 =head1 NAME
 
 Tie::Hash::FixedKeys - Perl extension for hashes with fixed keys
@@ -10,11 +8,11 @@ Tie::Hash::FixedKeys - Perl extension for hashes with fixed keys
 
   my @keys = qw(forename surname date_of_birth gender);
   my %person;
-  tie %person, 'Tie;::Hash::FixedKeys', @keys;
+  tie %person, 'Tie::Hash::FixedKeys', @keys;
 
   @person{@keys} = qw(Fred Bloggs 19700101 M);
 
-  $person{height} = "6'"; # generates a warning
+  $person{height} = "6'"; # generates an exception
 
 or (new! improved!)
 
@@ -33,9 +31,9 @@ the code:
   my %person;
   tie %person, 'Tie;::Hash::FixedKeys', @keys;
 
-the hash C<%person> can only contain the keys forename, surname, 
+the hash C<%person> can only contain the keys forename, surname,
 date_of_birth and gender. Any attempt to set a value for another key
-will generate a run-time warning.
+will generate a run-time exception.
 
 =head2 ATTRIBUTE INTERFACE
 
@@ -53,14 +51,14 @@ value is reset to C<undef>.
 
 Versions of Perl from 5.8.0 include a module called L<Hash::Util> which
 contains a function called C<lock_keys> which does the same as this module
-but in a faster and more powerful way. I recommend that you use that 
+but in a faster and more powerful way. I recommend that you use that
 method in place of this module.
 
 This module is left on CPAN as an example of tied hashes.
 
 =cut
 
-package Tie::Hash::FixedKeys; 
+package Tie::Hash::FixedKeys;
 
 use 5.006;
 use strict;

--- a/lib/Tie/Hash/FixedKeys.pm
+++ b/lib/Tie/Hash/FixedKeys.pm
@@ -67,7 +67,7 @@ use warnings;
 use Tie::Hash;
 use Carp;
 
-use Attribute::Handlers autotie => { "__CALLER__::FixedKeys" => __PACKAGE__ };
+use Attribute::Handlers autotie => { '__CALLER__::FixedKeys' => __PACKAGE__ };
 
 our @ISA = qw(Tie::StdHash);
 
@@ -85,7 +85,7 @@ sub TIEHASH {
   my $class = shift;
 
   my %hash;
-  @hash{@_} = (undef) x @_;
+  @hash{@_} = ();
 
   bless \%hash, $class;
 }
@@ -132,10 +132,11 @@ Clears all values but resetting them to C<undef>.
 =cut
 
 sub CLEAR {
-  my $self = shift;
+  my ($self) = @_;
 
-  $self->{$_} = undef foreach keys %$self;
+  @{$self}{keys %$self} = ();
 }
+
 
 1;
 __END__

--- a/t/test.t
+++ b/t/test.t
@@ -14,6 +14,7 @@ $hash{two} = 2;
 ok($hash{two} == 2);
 
 eval { $hash{four} = 4 };
+ok($@ ne '');
 ok(not defined $hash{four});
 ok(not exists $hash{four});
 
@@ -26,7 +27,7 @@ ok(not defined $hash{four});
 ok(not exists $hash{four});
 
 %hash = ();
-ok(not defined $hash{one});
-ok(exists $hash{one});
+ok(not defined $hash{two});
+ok(exists $hash{two});
 
 done_testing();


### PR DESCRIPTION
The configure steps raises some warnings that should be resolved by the author:-(

```
perl Build.PL
WARNING: the following files are missing in your kit:
        Makefile.PL
        META.json
        META.yml
Please inform the author.

Could not get valid metadata. Error is: Invalid metadata structure. Errors: Missing mandatory field, 'release_status' (release_status) [Validation: 2], Expected a list structure (resources -> license) [Validation: 2], Expected a list structure (license) [Validation: 2], Custom key 'requires' must begin with 'x_' or 'X_'. (requires) [Validation: 2]
 at /opt/perlbrew/perls/perl-5.14.4-cleanup-libpath/lib/5.14.4/Module/Build/Base.pm line 4559

Could not create MYMETA files
Creating new 'Build' script for 'Tie-Hash-FixedKeys' version 'v1.13.2'
```